### PR TITLE
📜 Fix policy attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ This Terraform module provisions the required resources for Analytical Platform'
 
 ## Usage
 
-### From Modernisation Platform Environments
-
 ```hcl
-module "observability_platform_tenant" {
-  source  = "ministryofjustice/observability-platform-tenant/aws"
-  version = "X.X.X"
+module "analytical_platform" {
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=<version>"
 
-  observability_platform_account_id = local.environment_management.account_ids["observability-platform-production"]
+  enable_cloudwatch_read_only_access    = true
+  enable_amazon_prometheus_query_access = true
+  enable_aws_xray_read_only_access      = true
+
+  additional_policies = {
+    managed_prometheus_kms_access = module.managed_prometheus_kms_access_iam_policy.arn
+  }
 
   tags = local.tags
 }
@@ -28,7 +31,3 @@ module "observability_platform_tenant" {
 ```bash
 make test
 ```
-
-### Contributing
-
-The base branch requires _all_ commits to be signed. Learn more about signing commits [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).

--- a/main.tf
+++ b/main.tf
@@ -30,20 +30,20 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_read_only_access" {
 resource "aws_iam_role_policy_attachment" "amazon_prometheus_query_access" {
   count = var.enable_amazon_prometheus_query_access ? 1 : 0
 
-  role       = module.iam_role.iam_role_arn
+  role       = module.iam_role.iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "aws_xray_read_only_access" {
   count = var.enable_aws_xray_read_only_access ? 1 : 0
 
-  role       = module.iam_role.iam_role_arn
+  role       = module.iam_role.iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "additional_policies" {
   for_each = { for k, v in var.additional_policies : k => v }
 
-  role       = module.iam_role.iam_role_arn
+  role       = module.iam_role.iam_role_name
   policy_arn = each.value
 }


### PR DESCRIPTION
## Proposed Changes

- Refers to role **name** instead of ARN to fix

```
Error: attaching IAM Policy (arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess) to IAM Role (arn:aws:iam::***:role/analytical-platform-observability): operation error IAM: AttachRolePolicy, https response error StatusCode: 400, RequestID: 57976715-a522-45cd-961c-86c48ac7186b, api error ValidationError: The specified value for roleName is invalid. It must contain only alphanumeric characters and/or the following: +=,.@_-
```

- Update README

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>