### PR TITLE
Update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
@@ -13,6 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: devcontainers"
       include: "scope"
@@ -20,6 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: docker"
       include: "scope"
@@ -27,6 +33,8 @@ updates:
     directory: "/tests"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: docker-compose"
       include: "scope"
@@ -34,6 +42,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: terraform"
       include: "scope"
@@ -41,6 +51,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: uv"
       include: "scope"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -17,4 +17,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-openssf-scorecard.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-openssf-scorecard.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-pre-commit-update.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-pre-commit-update.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: read
       statuses: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0
     with:
       super-linter-variables: |
         {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set Up UV
         id: setup_uv
-        uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           activate-environment: true
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set Up Terraform
         id: setup_terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Test
         id: test

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8# v7.1.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8# v7.1.0


### PR DESCRIPTION
Tracked [here](https://github.com/ministryofjustice/analytical-platform-security/issues/26) as part of pinning GHAs to SHAs, these were all pinned, so updated.

This pull request updates several GitHub Actions workflows and configuration files to use newer versions of actions and to improve dependency management. The main changes are upgrading action versions for better features and security, and introducing a cooldown period for Dependabot updates to reduce noise from frequent pull requests.

**GitHub Actions Upgrades:**

* Updated all references to `ministryofjustice/analytical-platform-github-actions` reusable workflows (dependency review, OpenSSF scorecard, pre-commit update, super-linter, and zizmor) from version `v4.6.0` to `v7.1.0` for improved functionality and security. [[1]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L17-R17) [[2]](diffhunk://#diff-2462706bed7e6e817d2961ac353dce113404d139fc511ed570f6890addbec9cbL20-R20) [[3]](diffhunk://#diff-e910bb884be9aeda4479f9c0ca50603c529e8c7ff2d14ad2063d696b7fff72d7L17-R17) [[4]](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L18-R18) [[5]](diffhunk://#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7L21-R21)
* Upgraded `actions/checkout` from `v5.0.0` to `v6.0.2` in the `test.yml` workflow.
* Updated `astral-sh/setup-uv` from `v6.5.0` to `v8.0.0` in the `test.yml` workflow.
* Upgraded `hashicorp/setup-terraform` from `v3.1.2` to `v4.0.0` in the `test.yml` workflow.

**Dependabot Configuration Improvements:**

* Added a `cooldown` period of 7 days to all package ecosystems in `.github/dependabot.yml` to limit the frequency of update pull requests, reducing noise and making dependency management more manageable.

 